### PR TITLE
Reporting and classifications

### DIFF
--- a/schematron/reports_unc_schematron.xml
+++ b/schematron/reports_unc_schematron.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" queryBinding="xslt2">
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="urn:isbn:1-931666-22-9" prefix="ead"/>
+
+  <phase id="manual">
+    <active pattern="nonmigrating-extref-attributes" />
+    <active pattern="migrating-extref-attributes" />
+    <active pattern="extref-container-types" />
+    <active pattern="containerized-extrefs" />
+    <active pattern="audience" />
+  </phase>
+
+    <pattern id="nonmigrating-extref-attributes">
+    <rule context="//extref">
+    <!-- nonmigrating 'extref' elements (i.e. fall outside of a 'c0x') -->
+    <!-- we assume that any c0x is a c01 or descendant of a c01-->
+      <report test="not(ancestor::c01) and (@role or @show or @actuate or @audience)" diagnostics="nonmigrating-extref-attributes">
+        nonmigrating extref attrs: '<value-of select="@role" />';'<value-of select="@show" />';'<value-of select="@actuate" />';'<value-of select="@audience" />';
+      </report>
+      <report test="not(ancestor::c01)" diagnostics="nonmigrating-extref-attributes">
+        nonmigrating extref href/text: href: '<value-of select="@href" />' text: '<value-of select="." />'
+      </report>
+    </rule>
+  </pattern>
+
+  <pattern id="migrating-extref-attributes">
+    <rule context="//*:c//extref|//*:c01//extref|//*:c02//extref|//*:c03//extref|//*:c04//extref|//*:c05//extref|//*:c06//extref|//*:c07//extref|//*:c08//extref|//*:c09//extref|//*:c10//extref|//*:c11//extref|//*:c12//extref">
+    <!-- 'extref' elements that are migrating (i.e. fall under a 'c0x' element) -->
+      <report test="(@role or @show or @actuate or @audience)" diagnostics="extref-attributes">
+        migrating extref attrs: '<value-of select="@role" />';'<value-of select="@show" />';'<value-of select="@actuate" />';'<value-of select="@audience" />';
+      </report>
+      <report test="not(@role or @show or @actuate or @audience)" diagnostics="extref-attributes">
+        migrating extref attrs: none
+      </report>
+      <report test="not(ancestor::container) and (matches(., '^[\s&#x9;]*[A-Z]+-\S*[\s&#x9;]*$'))" diagnostics="noncontainerized-extref-dfdi-identifiers">
+        noncontainerized migrating extref has DF/DI-like tag: '<value-of select="." />'
+      </report>
+    </rule>
+  </pattern>
+
+  <pattern id="extref-container-types">
+    <rule context="//did//container">
+    <!-- any 'container' element under a 'did'-->
+      <report test=".//extref and not(@type='digfolder' or @type='digitem')" diagnostics="containzerized-extref-container-types">
+        containerized extref with non df/di type: '<value-of select="@type" />'
+      </report>
+    </rule>
+  </pattern>
+
+  <pattern id="containerized-extrefs">
+    <rule context="//did//container//extref">
+    <!-- any containerized 'extref' element -->
+    <!-- We want this to report any text that does not match ruby's /^\s*D[FI]-\S+\s*$/
+         but it seems like XSLT flavor of regexp \s does not include tab -->
+      <report test="not(matches(., '^[\s&#x9;]*D[FI]-\S*[\s&#x9;]*$'))" diagnostics="containerized-extref-identifiers">
+        extref with non DF/DI identifier text: '<value-of select="." />'
+      </report>
+    </rule>
+  </pattern>
+
+  <pattern id="audience">
+    <rule context="//*[@audience]">
+    <!-- any element with an 'audience' attr -->
+      <report test="@audience and not(local-name(.) = 'eadheader')" diagnostics="audience-attributes">
+        audience: '<value-of select="@audience" />'
+      </report>
+    </rule>
+  </pattern>
+
+  <diagnostics>
+    <diagnostic id="nonmigrating-extref-attributes">Ref-number: AS-326</diagnostic>
+    <diagnostic id="extref-attributes">Ref-number: AS-326</diagnostic>
+    <diagnostic id="noncontainerized-extref-dfdi-identifiers">Ref-number: AS-353</diagnostic>
+    <diagnostic id="containzerized-extref-container-types">Ref-number: AS-353</diagnostic>
+    <diagnostic id="containerized-extref-identifiers">Ref-number: AS-353</diagnostic>
+    <diagnostic id="audience-attributes">Ref-number: AS-326 (tangent)</diagnostic>
+  </diagnostics>
+</schema>

--- a/schematron/unc_schematron.xml
+++ b/schematron/unc_schematron.xml
@@ -5,6 +5,7 @@
 
   <phase id="manual">
     <active pattern="descgrp-manual" />
+    <active pattern="ead-id-attr-manual" />
     <active pattern="did-manual" />
     <active pattern="table-manual" />
     <active pattern="daodesc-manual" />
@@ -43,6 +44,15 @@
     <rule context="//*:descgrp[@type]">
       <!-- 'descgrp' elements with type 'add' -->
       <assert test="not(@type='add')" diagnostics="dm-1">'descgrp' is deprecated, and must be removed. 'descgrp' element with type 'add' requires manual review and intervention.</assert>
+    </rule>
+  </pattern>
+
+  <pattern id="ead-id-attr-manual">
+    <rule context="/*:ead">
+    <!-- 'id' attribute of root ead element-->
+    <assert test="@id = ('ncc', 'nccpa', 'nccu', 'nccu-offsite', 'rbc', 'sfc', 'shc', 'ua', 'ulgac')" diagnostics="ead-id-attr">
+        '<value-of select="@id" />' is blank or an unrecognized repo/collecting-unit code
+    </assert>
     </rule>
   </pattern>
 
@@ -505,7 +515,7 @@
     <diagnostic id="date-title">Ref-number: AS-243</diagnostic>
     <diagnostic id="langcode">Ref-number: AS-243</diagnostic>
     <diagnostic id="extref-href">Ref-number: AS-317</diagnostic>
-
+    <diagnostic id="ead-id-attr">Ref-number: AS-329</diagnostic>
 
     <!--  Logic seems wrong and duplicative?:  -->
     <!--    <diagnostic id="note-1">Ref-number: AS-38</diagnostic>  -->

--- a/schematron/unc_schematron.xml
+++ b/schematron/unc_schematron.xml
@@ -93,8 +93,10 @@
         'did' elements must contain a either a 'unitdate' element, a non-empty 'unittitle' element or both.
       </assert>
 
-      <assert test="*:unitdate/descendant-or-self::*/text()[normalize-space(.)] or *:unittitle/descendant-or-self::*/text()[normalize-space(.)]" diagnostics="date-title">
-        'did' elements must contain a unittitle or unitdate (or both) that contains text or a descendant that contains text
+      <assert test="*:unittitle/descendant-or-self::*/text()[normalize-space(.)]" diagnostics="date-title">
+        <!-- Aspace will accept either a unittitle or unitdate here, but per AS-350 we are
+             requiring a unittitle -->
+        'did' elements must contain a unittitle that contains text (or a descendant that contains text)
       </assert>
     </rule>
 
@@ -512,7 +514,7 @@
     <diagnostic id="abstract">Ref-number: AS-243</diagnostic>
     <diagnostic id="component-id">Ref-number: AS-236</diagnostic>
     <diagnostic id="date-type">Ref-number: AS-243</diagnostic>
-    <diagnostic id="date-title">Ref-number: AS-243</diagnostic>
+    <diagnostic id="date-title">Ref-number: AS-350/AS-243</diagnostic>
     <diagnostic id="langcode">Ref-number: AS-243</diagnostic>
     <diagnostic id="extref-href">Ref-number: AS-317</diagnostic>
     <diagnostic id="ead-id-attr">Ref-number: AS-329</diagnostic>


### PR DESCRIPTION
- AS-329: require ead elements to contain an id attribute with a recognized collecting unit / classification id
- AS-350: require did elements to contain a non-empty unittitle (instead of non-empty unittitle-or-unitdate)
- Add a separate schematron for misc reporting on data (rather than reporting errors)
  -  Covers reporting on extref properties related to AS-326 and AS-353