### PR TITLE
extref updates

### DIFF
--- a/schematron/reports_unc_schematron.xml
+++ b/schematron/reports_unc_schematron.xml
@@ -12,21 +12,21 @@
   </phase>
 
     <pattern id="nonmigrating-extref-attributes">
-    <rule context="//extref">
-    <!-- nonmigrating 'extref' elements (i.e. fall outside of a 'c0x') -->
+    <rule context="//extref[not(ancestor::container) and not(ancestor::unittitle and ancestor::c01)]">
+    <!-- nonmigrating 'extref' elements -->
     <!-- we assume that any c0x is a c01 or descendant of a c01-->
-      <report test="not(ancestor::c01) and (@role or @show or @actuate or @audience)" diagnostics="nonmigrating-extref-attributes">
+      <report test="@role or @show or @actuate or @audience" diagnostics="nonmigrating-extref-attributes">
         nonmigrating extref attrs: '<value-of select="@role" />';'<value-of select="@show" />';'<value-of select="@actuate" />';'<value-of select="@audience" />';
       </report>
-      <report test="not(ancestor::c01)" diagnostics="nonmigrating-extref-attributes">
+      <report test="." diagnostics="nonmigrating-extref-attributes">
         nonmigrating extref href/text: href: '<value-of select="@href" />' text: '<value-of select="." />'
       </report>
     </rule>
   </pattern>
 
   <pattern id="migrating-extref-attributes">
-    <rule context="//*:c//extref|//*:c01//extref|//*:c02//extref|//*:c03//extref|//*:c04//extref|//*:c05//extref|//*:c06//extref|//*:c07//extref|//*:c08//extref|//*:c09//extref|//*:c10//extref|//*:c11//extref|//*:c12//extref">
-    <!-- 'extref' elements that are migrating (i.e. fall under a 'c0x' element) -->
+    <rule context="//did/container//extref|//*:c/did//unittitle//extref|//*:c01/did//unittitle//extref|//*:c02/did//unittitle//extref|//*:c03/did//unittitle//extref|//*:c04/did//unittitle//extref|//*:c05/did//unittitle//extref|//*:c06/did//unittitle//extref|//*:c07/did//unittitle//extref|//*:c08/did//unittitle//extref|//*:c09/did//unittitle//extref|//*:c10/did//unittitle//extref|//*:c11/did//unittitle//extref|//*:c12/did//unittitle//extref">
+    <!-- 'extref' elements that are migrating -->
       <report test="(@role or @show or @actuate or @audience)" diagnostics="extref-attributes">
         migrating extref attrs: '<value-of select="@role" />';'<value-of select="@show" />';'<value-of select="@actuate" />';'<value-of select="@audience" />';
       </report>
@@ -40,16 +40,18 @@
   </pattern>
 
   <pattern id="extref-container-types">
-    <rule context="//did//container">
-    <!-- any 'container' element under a 'did'-->
-      <report test=".//extref and not(@type='digfolder' or @type='digitem')" diagnostics="containzerized-extref-container-types">
+    <rule context="//did/container[descendant::extref]">
+    <!-- any 'container' element with an extref-->
+    <!-- extrefs in non-digfolder/digitem containers are allowed and will migrate;
+         this identifies those non-digfolder/digitem container types-->
+      <report test="not(@type='digfolder' or @type='digitem')" diagnostics="containzerized-extref-container-types">
         containerized extref with non df/di type: '<value-of select="@type" />'
       </report>
     </rule>
   </pattern>
 
   <pattern id="containerized-extrefs">
-    <rule context="//did//container//extref">
+    <rule context="//did/container//extref">
     <!-- any containerized 'extref' element -->
     <!-- We want this to report any text that does not match ruby's /^\s*D[FI]-\S+\s*$/
          but it seems like XSLT flavor of regexp \s does not include tab -->

--- a/schematron/reports_unc_schematron.xml
+++ b/schematron/reports_unc_schematron.xml
@@ -7,7 +7,6 @@
     <active pattern="nonmigrating-extref-attributes" />
     <active pattern="migrating-extref-attributes" />
     <active pattern="extref-container-types" />
-    <active pattern="containerized-extrefs" />
     <active pattern="audience" />
   </phase>
 
@@ -33,9 +32,6 @@
       <report test="not(@role or @show or @actuate or @audience)" diagnostics="extref-attributes">
         migrating extref attrs: none
       </report>
-      <report test="not(ancestor::container) and (matches(., '^[\s&#x9;]*[A-Z]+-\S*[\s&#x9;]*$'))" diagnostics="noncontainerized-extref-dfdi-identifiers">
-        noncontainerized migrating extref has DF/DI-like tag: '<value-of select="." />'
-      </report>
     </rule>
   </pattern>
 
@@ -46,17 +42,6 @@
          this identifies those non-digfolder/digitem container types-->
       <report test="not(@type='digfolder' or @type='digitem')" diagnostics="containzerized-extref-container-types">
         containerized extref with non df/di type: '<value-of select="@type" />'
-      </report>
-    </rule>
-  </pattern>
-
-  <pattern id="containerized-extrefs">
-    <rule context="//did/container//extref">
-    <!-- any containerized 'extref' element -->
-    <!-- We want this to report any text that does not match ruby's /^\s*D[FI]-\S+\s*$/
-         but it seems like XSLT flavor of regexp \s does not include tab -->
-      <report test="not(matches(., '^[\s&#x9;]*D[FI]-\S*[\s&#x9;]*$'))" diagnostics="containerized-extref-identifiers">
-        extref with non DF/DI identifier text: '<value-of select="." />'
       </report>
     </rule>
   </pattern>
@@ -73,9 +58,7 @@
   <diagnostics>
     <diagnostic id="nonmigrating-extref-attributes">Ref-number: AS-326</diagnostic>
     <diagnostic id="extref-attributes">Ref-number: AS-326</diagnostic>
-    <diagnostic id="noncontainerized-extref-dfdi-identifiers">Ref-number: AS-353</diagnostic>
     <diagnostic id="containzerized-extref-container-types">Ref-number: AS-353</diagnostic>
-    <diagnostic id="containerized-extref-identifiers">Ref-number: AS-353</diagnostic>
     <diagnostic id="audience-attributes">Ref-number: AS-326 (tangent)</diagnostic>
   </diagnostics>
 </schema>

--- a/schematron/unc_schematron.xml
+++ b/schematron/unc_schematron.xml
@@ -388,8 +388,14 @@
   </pattern>
 
   <pattern id="extref-manual">
-    <rule context="//did//container//extref">
-    <!-- 'extref' elements that are migrating (i.e. fall under //did//container) -->
+    <rule context="//did/container//extref|//*:c/did//unittitle//extref|//*:c01/did//unittitle//extref|//*:c02/did//unittitle//extref|//*:c03/did//unittitle//extref|//*:c04/did//unittitle//extref|//*:c05/did//unittitle//extref|//*:c06/did//unittitle//extref|//*:c07/did//unittitle//extref|//*:c08/did//unittitle//extref|//*:c09/did//unittitle//extref|//*:c10/did//unittitle//extref|//*:c11/did//unittitle//extref|//*:c12/did//unittitle//extref">
+      <!-- 'extref' elements that are migrating, i.e. fall under one of:
+              - //c0x/did/container//extref
+              - //c0x/did//unittitle//extref
+            Note we do not need to specify the c0x in the container context xpath
+            because another rule already ensures no containers in a collection
+            level 'did'
+      -->
       <assert test="@href and not(@href = '')" diagnostics="extref-href">
         migrating 'extref' elements must have a non-empty href attribute
       </assert>
@@ -527,6 +533,7 @@
     <diagnostic id="date-type">Ref-number: AS-243</diagnostic>
     <diagnostic id="date-title">Ref-number: AS-350/AS-243</diagnostic>
     <diagnostic id="langcode">Ref-number: AS-243</diagnostic>
+    <diagnostic id="extref-href">Ref-number: AS-317, AS-358</diagnostic>
     <diagnostic id="digcontainer-extref">Ref-number: AS-352</diagnostic>
     <diagnostic id="ead-id-attr">Ref-number: AS-329</diagnostic>
 

--- a/schematron/unc_schematron.xml
+++ b/schematron/unc_schematron.xml
@@ -28,6 +28,7 @@
     <active pattern="abstract-manual" />
     <active pattern="component-manual" />
     <active pattern="extref-manual" />
+    <active pattern="digcontainer-manual" />
     <active pattern="langcode-manual" />
   </phase>
 
@@ -395,6 +396,16 @@
     </rule>
   </pattern>
 
+  <pattern id="digcontainer-manual">
+    <rule context="//*:container[@type = 'digfolder' or @type = 'digitem']">
+      <!-- 'container' element of type digfolder/digitem -->
+      <!-- other container types MAY contain migrating extrefs but only
+           digfolder/digitem container MUST contain an extref-->
+      <assert test=".//extref" diagnostics="digcontainer-extref">
+        'container' elements of type digfolder/digitem must contain an 'extref' element.
+      </assert>
+    </rule>
+  </pattern>
   <pattern id="langcode-manual">
       <rule context="//*:language[@langcode]">
       <!-- 'langcode' attribute of any language element-->
@@ -516,7 +527,7 @@
     <diagnostic id="date-type">Ref-number: AS-243</diagnostic>
     <diagnostic id="date-title">Ref-number: AS-350/AS-243</diagnostic>
     <diagnostic id="langcode">Ref-number: AS-243</diagnostic>
-    <diagnostic id="extref-href">Ref-number: AS-317</diagnostic>
+    <diagnostic id="digcontainer-extref">Ref-number: AS-352</diagnostic>
     <diagnostic id="ead-id-attr">Ref-number: AS-329</diagnostic>
 
     <!--  Logic seems wrong and duplicative?:  -->

--- a/schematron/unc_schematron.xml
+++ b/schematron/unc_schematron.xml
@@ -29,6 +29,8 @@
     <active pattern="component-manual" />
     <active pattern="extref-manual" />
     <active pattern="digcontainer-manual" />
+    <active pattern="containerized-extref-manual" />
+    <active pattern="migrating-noncontainerized-extref-manual" />
     <active pattern="langcode-manual" />
   </phase>
 
@@ -412,6 +414,27 @@
       </assert>
     </rule>
   </pattern>
+
+  <pattern id="containerized-extref-manual">
+    <rule context="//did/container[descendant::extref]">
+      <!-- any 'container' element with an extref-->
+      <!-- We want this to report any text that does not match ruby's /^\s*(DF|DI|etc)-\S+\s*$/
+           but it seems like XSLT flavor of regexp \s does not include tab -->
+      <assert test="matches(.//extref, '^[\s&#x9;]*(DF|DI|DCD|FLD|EKAAMP)-\S*[\s&#x9;]*$')" diagnostics="containerized-extref-identifiers">
+        containerized extrefs must contain DF/DI identifier text. Found: '<value-of select="normalize-space(.//extref)" />'
+      </assert>
+    </rule>
+  </pattern>
+
+  <pattern id="migrating-noncontainerized-extref-manual">
+    <rule context="//*:c/did//unittitle//extref|//*:c01/did//unittitle//extref|//*:c02/did//unittitle//extref|//*:c03/did//unittitle//extref|//*:c04/did//unittitle//extref|//*:c05/did//unittitle//extref|//*:c06/did//unittitle//extref|//*:c07/did//unittitle//extref|//*:c08/did//unittitle//extref|//*:c09/did//unittitle//extref|//*:c10/did//unittitle//extref|//*:c11/did//unittitle//extref|//*:c12/did//unittitle//extref">
+      <!-- migrating noncontainzerized 'extref' elements -->
+      <assert test="not(matches(., '^[\s&#x9;]*[A-Z]+-\S*[\s&#x9;]*$'))" diagnostics="noncontainerized-extref-dfdi-identifiers">
+        noncontainerized migrating extrefs should not have DF/DI identifier-like text:  Found: '<value-of select="normalize-space(.)" />'
+      </assert>
+    </rule>
+  </pattern>
+
   <pattern id="langcode-manual">
       <rule context="//*:language[@langcode]">
       <!-- 'langcode' attribute of any language element-->
@@ -535,6 +558,8 @@
     <diagnostic id="langcode">Ref-number: AS-243</diagnostic>
     <diagnostic id="extref-href">Ref-number: AS-317, AS-358</diagnostic>
     <diagnostic id="digcontainer-extref">Ref-number: AS-352</diagnostic>
+    <diagnostic id="containerized-extref-identifiers">Ref-number: AS-XXX/AS-353 TODO/TBD</diagnostic>
+    <diagnostic id="noncontainerized-extref-dfdi-identifiers">Ref-number: AS-XXX/AS-353 TODO/TBD</diagnostic>
     <diagnostic id="ead-id-attr">Ref-number: AS-329</diagnostic>
 
     <!--  Logic seems wrong and duplicative?:  -->


### PR DESCRIPTION
- AS-352: assert digfolder/digitem containers have an extref
- AS-358: Update definitions of migrating/nonmigrating extrefs
  - Incorporate AS-320's clarification that migrating noncontainerized extrefs would be in limited to extrefs under a c0x and in a unittitle field rather than just any extref under a c0x
  - Match the more precise xpaths AS-356 uses in the converter for both containerized and noncontainerized extrefs (e.g. `//did/container//extref` instead of `//did//container//extref`)
- AS-381: treat DF/DI identifier expectations as manual errors
  - assert containerized extrefs to have a DF/DI identifier
  - assert migrating noncontainerized extrefs lack DF/DI identifiers