### PR TITLE
AS-438 controlaccess children

### DIFF
--- a/schematron/unc_schematron.xml
+++ b/schematron/unc_schematron.xml
@@ -366,6 +366,19 @@
       <assert test="text()[normalize-space(.)]" diagnostics="controlaccess-3">
         'controlaccess' children must contain text
       </assert>
+
+      <assert test="not(./descendant::title or ./descendant::corpname or ./descendant::persname or ./descendant::famname
+                        or ./descendant::function or ./descendant::genreform or ./descendant::geogname
+                        or ./descendant::occupation or ./descendant::subject)" diagnostics="controlaccess-4">
+        controlaccess children must not be nested in other controlaccess children.
+      </assert>
+    </rule>
+
+    <rule context="//*:controlaccess//*:item">
+      <!-- 'item' in 'controlaccess'-->
+      <assert test="not(text()[normalize-space(.)])" diagnostics="controlaccess-4">
+        controlaccess 'item' should not contain text outside of the controlaccess child.
+      </assert>
     </rule>
   </pattern>
 
@@ -549,6 +562,10 @@
     <diagnostic id="controlaccess-1">Ref-number: AS-49</diagnostic>
     <diagnostic id="controlaccess-2">Ref-number: AS-98</diagnostic>
     <diagnostic id="controlaccess-3">Ref-number: AS-243</diagnostic>
+    <diagnostic id="controlaccess-4">Ref-number: AS-438</diagnostic>
+    <diagnostic id="controlaccess-5">Ref-number: AS-438
+      CHILD: '<value-of select="./child::*" />' SELF: '<value-of select="text()[normalize-space(.)]" />'
+    </diagnostic>
     <diagnostic id="abstract">Ref-number: AS-243</diagnostic>
     <diagnostic id="component-id">Ref-number: AS-236</diagnostic>
     <diagnostic id="date-type">Ref-number: AS-243</diagnostic>

--- a/schematron/unc_schematron.xml
+++ b/schematron/unc_schematron.xml
@@ -352,19 +352,17 @@
       </assert>
     </rule>
 
-    <rule context="//*:item/*[*:corpname or *:persname or *:famname or *:function or *:genreform or *:geogname
-                  or *:occupation or *:subject or *:title]">
-      <!-- 'controlaccess/list' elements -->
-      <assert test="./ancestor::*/controlaccess" diagnostics="controlaccess-2">
-        Lists containing 'corpname', 'persname', 'famname', 'function', 'genreform', 'geogname', 'occupation', 'subject', or 'title' elements can only be parsed as children of 'controlaccess' elements.
-      </assert>
-    </rule>
-
     <rule context="//*:item/*:corpname|//*:item/*:persname|//*:item/*:famname|
                    //*:item/*:function|//*:item/*:genreform|//*:item/*:geogname|
                    //*:item/*:occupation|//*:item/*:subject|
                    //*:item/*:title">
       <!-- 'controlaccess' children (that are migrating/valid)-->
+
+      <!-- NOTE: we allow 'title' in lists outside of 'controlaccess' -->
+      <assert test="./ancestor::controlaccess or local-name(.) = 'title'" diagnostics="controlaccess-2">
+        Lists containing 'corpname', 'persname', 'famname', 'function', 'genreform', 'geogname', 'occupation', or 'subject' elements can only be parsed as children of 'controlaccess' elements.
+      </assert>
+
       <assert test="text()[normalize-space(.)]" diagnostics="controlaccess-3">
         'controlaccess' children must contain text
       </assert>

--- a/schematron/unc_schematron.xml
+++ b/schematron/unc_schematron.xml
@@ -346,7 +346,7 @@
       <assert test="count(./*:corpname|./*:persname|./*:famname|./*:function|./*:genreform|./*:geogname|./*:occupation|./*:subject|./*:title|./*:list|./*:head) = count(./*)
                     and count(./*:list/*:item/*:corpname|./*:list/*:item/*:persname|./*:list/*:item/*:famname|
                     ./*:list/*:item/*:function|./*:list/*:item/*:genreform|./*:list/*:item/*:geogname|
-                    ./*:list/*:item/*:occupation|./*:list/*:item/*:subject|./*:list/*:item/*:title) = count(./*:list/*:item/*)"
+                    ./*:list/*:item/*:occupation|./*:list/*:item/*:subject|./*:list/*:item/*:title) = count(./*:list/*:item)"
               diagnostics="controlaccess-1">
         The only 'controlaccess' children that will migrate are: 'corpname', 'persname', 'famname', 'function', 'genreform', 'geogname', 'occupation', 'subject', 'title'.
       </assert>

--- a/schematron/unc_schematron.xml
+++ b/schematron/unc_schematron.xml
@@ -376,7 +376,7 @@
 
     <rule context="//*:controlaccess//*:item">
       <!-- 'item' in 'controlaccess'-->
-      <assert test="not(text()[normalize-space(.)])" diagnostics="controlaccess-4">
+      <assert test="not(text()[normalize-space(.)])" diagnostics="controlaccess-5">
         controlaccess 'item' should not contain text outside of the controlaccess child.
       </assert>
     </rule>


### PR DESCRIPTION
- Fix test requiring controlaccess children to be under controlaccess and exempt `title` from this requirement
- Add tests forbidding non-migrating elements/text from existing under controlaccess

https://unclibrary.atlassian.net/browse/AS-438